### PR TITLE
fix(pict): spec-conformance fixes + comment classification

### DIFF
--- a/docs/contents/reference/pict.mdx
+++ b/docs/contents/reference/pict.mdx
@@ -46,7 +46,7 @@ new PictModel(input: string, options?: PictModelOptions)
 
 The input string is split into three sections:
 1. **Parameters** — `Name: value1, value2, ...`
-2. **Sub-models** — `{ A, B, C } @ N`
+2. **Sub-models** — `{ A, B, C } @ N` (the `@ N` order is optional; when omitted it defaults to the global order)
 3. **Constraints** — `IF [P] = "x" THEN [Q] = "y";` or unconditional `[P] <> [Q];`
 
 ## Properties
@@ -103,10 +103,12 @@ model.issues;
 | **Aliases** | `OS: Windows \| Win, Linux` | First value is canonical. Aliases work in constraints. |
 | **Invalid values** | `Type: Valid, ~Invalid` | Negative-test value. At most one per row. Output includes `~` prefix. |
 | **Weights** | `Browser: Chrome (10), Firefox` | Biases value selection during completion. |
-| **Sub-models** | `{ A, B, C } @ 3` | Different N-wise strength for listed parameters. |
+| **Sub-models** | `{ A, B, C } @ 3` or `{ A, B, C }` | Different N-wise strength for listed parameters. The `@ N` order is optional and defaults to the global order. |
 | **Conditional** | `IF [A] = 1 THEN [B] = 2;` | Standard PICT-style conditional constraints. |
 | **Unconditional** | `[A] <> [B];` | Always-applied invariants. |
-| **Comparisons** | `=`, `<>`, `>`, `<`, `>=`, `<=`, `IN`, `LIKE` | All standard PICT operators. |
+| **Comparisons** | `=`, `<>`, `>`, `<`, `>=`, `<=` | All standard PICT operators. |
+| **Set membership** | `[FS] IN {"FAT", "NTFS"}`, `[Size] IN {512, 1024}` | `IN` accepts string **and** numeric sets. |
+| **Pattern** | `[Name] LIKE "FAT*"` | `LIKE` matches with wildcards `*` (any run) and `?` (one char); every other character (e.g. `.`) is literal. |
 | **Logical** | `AND`, `OR`, `NOT` | With parentheses for grouping. |
 
 ## Invalid Values (`~`)
@@ -201,6 +203,7 @@ CoverTable's `PictModel` accepts PICT-format input, but the underlying engine wo
 | **Structure** | Fully hierarchical — sub-models are independent `Model` instances combined via pseudo-parameters | Flat key-set partitioning with per-set strength |
 | **Nesting** | Sub-models can be nested arbitrarily | Single level only |
 | **Overlap** | Parameters can appear in multiple sub-models; conflicts resolved by exclusion generation | Each parameter belongs to at most one sub-model |
+| **Default order** | An omitted `@ N` uses the `/o` order | An omitted `@ N` uses the global (`strength`) order — same behavior |
 
 ### Weights
 

--- a/docs/contents/tools/pict-online.mdx
+++ b/docs/contents/tools/pict-online.mdx
@@ -80,8 +80,8 @@ make({ machine, os, browser }, {
 | `=` / `<>` | `[os] = "iOS"` / `[os] <> "Android"` | Equality / Inequality |
 | `>` / `<` / `>=` / `<=` | `[price] > 100` | Numeric comparisons |
 | `AND` / `OR` / `NOT` | `[os] = "iOS" AND [browser] = "Safari"` | Logical operators with parentheses |
-| `LIKE` | `[machine] LIKE "i*"` | Pattern matching with `*` and `?` |
-| `IN` | `[os] IN {"iOS", "Android"}` | Set membership |
+| `LIKE` | `[machine] LIKE "i*"` | Pattern matching with `*` and `?` (all other characters are literal) |
+| `IN` | `[os] IN {"iOS", "Android"}`, `[size] IN {512, 1024}` | Set membership (string or numeric sets) |
 
 ### Parameters
 
@@ -93,4 +93,4 @@ make({ machine, os, browser }, {
 | **Invalid (`~`)** | `Type: A, ~Bad` | Negative-test value (at most one per row) |
 | **Weight** | `Browser: Chrome (10), Firefox` | Bias value selection during completion |
 | **Reference** | `B: <A>, extra` | Inherit values from another parameter |
-| **Sub-model** | `{ A, B, C } @ 3` | Apply different N-wise strength to a group |
+| **Sub-model** | `{ A, B, C } @ 3` or `{ A, B, C }` | Apply different N-wise strength to a group; `@ N` is optional (defaults to the global order) |

--- a/python/covertable/main.py
+++ b/python/covertable/main.py
@@ -131,8 +131,9 @@ class Controller:
                 pairs.append(tuple(sorted(pair)))
 
         for sm in self.sub_models:
-            for keys in combinations(sm["fields"], sm["strength"]):
-                comb = [self.serials[keys[i]] for i in range(sm["strength"])]
+            sub_strength = sm.get("strength", self.strength)
+            for keys in combinations(sm["fields"], sub_strength):
+                comb = [self.serials[keys[i]] for i in range(sub_strength)]
                 for pair in product(*comb):
                     pairs.append(tuple(sorted(pair)))
 
@@ -342,7 +343,7 @@ class Controller:
     def all_strengths(self):
         strengths = {self.strength}
         for sm in self.sub_models:
-            strengths.add(sm["strength"])
+            strengths.add(sm.get("strength", self.strength))
         return strengths
 
     def get_candidate(self, pair):

--- a/python/covertable/pict/lexer.py
+++ b/python/covertable/pict/lexer.py
@@ -363,6 +363,9 @@ class PictConstraintsLexer:
                         lookup = raw.lower() if ci else raw
                         resolved = aliases.get(lookup, raw)
                         elements.append(norm(resolved))
+                    elif tok["type"] == _NUMBER:
+                        num = float(tok["value"])
+                        elements.append(int(num) if num.is_integer() else num)
                     elif tok["type"] not in (_COMMA, _WHITESPACE):
                         raise ValueError("Unexpected token in array: {}".format(tok["value"]))
                     tok = next_token()

--- a/python/covertable/pict/parser.py
+++ b/python/covertable/pict/parser.py
@@ -162,8 +162,9 @@ def parse_pict_model(input_str):
     }
 
 
-# Sub-model line: { P1, P2, P3 } @ N
-SUB_MODEL_PATTERN = re.compile(r"^\{\s*(.+?)\s*\}\s*@\s*(\d+)\s*$")
+# Sub-model line: { P1, P2, P3 } @ N  — the "@ N" order is optional and, when
+# absent, the global order (/o) is applied at generation time.
+SUB_MODEL_PATTERN = re.compile(r"^\{\s*(.+?)\s*\}\s*(?:@\s*(\d+))?\s*$")
 
 
 def parse_sub_model(line):
@@ -171,5 +172,6 @@ def parse_sub_model(line):
     if not match:
         return None
     keys = [k.strip() for k in match.group(1).split(",") if k.strip()]
-    strength = int(match.group(2))
-    return {"fields": keys, "strength": strength}
+    if match.group(2) is None:
+        return {"fields": keys}
+    return {"fields": keys, "strength": int(match.group(2))}

--- a/python/test_pict.py
+++ b/python/test_pict.py
@@ -185,6 +185,45 @@ IF [Cluster] IN {512, 1024} THEN [Compression] = "Off";
         assert model.filter({"Cluster": 512, "Compression": "On"}) is False
         assert model.filter({"Cluster": 2048, "Compression": "On"}) is True
 
+    def test_float_in_clause(self):
+        model = PictModel("""
+V: 1, 2.5, 3
+R: ok, ng
+
+IF [V] IN {2.5, 3} THEN [R] = "ok";
+""")
+        assert model.errors == []
+        assert model.filter({"V": 2.5, "R": "ok"}) is True
+        assert model.filter({"V": 3, "R": "ng"}) is False
+        assert model.filter({"V": 1, "R": "ng"}) is True
+
+    def test_like_treats_non_wildcards_as_literals(self):
+        # Only * and ? are wildcards; "." must match a literal dot.
+        model = PictModel("""
+Ver: "4.8", "4.8.1", "4x8"
+Ok: yes, no
+
+IF [Ver] LIKE "4.8*" THEN [Ok] = "yes";
+""")
+        assert model.errors == []
+        assert model.filter({"Ver": "4.8", "Ok": "yes"}) is True
+        assert model.filter({"Ver": "4.8.1", "Ok": "yes"}) is True
+        # "4x8" must NOT match "4.8*" because the dot is literal.
+        assert model.filter({"Ver": "4x8", "Ok": "no"}) is True
+        assert model.filter({"Ver": "4.8", "Ok": "no"}) is False
+
+    def test_like_wildcards(self):
+        model = PictModel("""
+Name: Alice, Alicia, Bob
+Tag: a, b
+
+IF [Name] LIKE "Alic?" THEN [Tag] = "a";
+""")
+        assert model.errors == []
+        assert model.filter({"Name": "Alice", "Tag": "a"}) is True    # ? = one char
+        assert model.filter({"Name": "Alicia", "Tag": "b"}) is True   # no match -> passes
+        assert model.filter({"Name": "Alice", "Tag": "b"}) is False
+
 
 # ---------------------------------------------------------------------------
 # Invalid values (~)

--- a/python/test_pict.py
+++ b/python/test_pict.py
@@ -172,6 +172,19 @@ IF [OS] IN {"Win10", "Mac"} THEN [Result] = "pass";
         assert model.filter({"OS": "Mac OS", "Result": "pass"}) is True
         assert model.filter({"OS": "Linux", "Result": "fail"}) is True
 
+    def test_numeric_in_clause(self):
+        # PICT's own example uses numeric IN sets (doc/pict.md).
+        model = PictModel("""
+Cluster: 512, 1024, 2048
+Compression: On, Off
+
+IF [Cluster] IN {512, 1024} THEN [Compression] = "Off";
+""")
+        assert model.errors == []
+        assert model.filter({"Cluster": 512, "Compression": "Off"}) is True
+        assert model.filter({"Cluster": 512, "Compression": "On"}) is False
+        assert model.filter({"Cluster": 2048, "Compression": "On"}) is True
+
 
 # ---------------------------------------------------------------------------
 # Invalid values (~)
@@ -243,6 +256,28 @@ D: d1, d2
                 for c in ["c1", "c2", "c3"]:
                     found = any(r["A"] == a and r["B"] == b and r["C"] == c for r in rows)
                     assert found, "missing combination ({}, {}, {})".format(a, b, c)
+
+    def test_sub_model_without_order_uses_global_order(self):
+        # Per PICT spec, an omitted "@ N" defaults to the global order (/o).
+        model = PictModel("""
+A: 1, 2
+B: 3, 4
+
+{ A, B }
+""")
+        assert model.errors == []
+        assert model.sub_models == [{"fields": ["A", "B"]}]
+        assert len(model.make()) > 0
+
+    def test_malformed_sub_model_order_produces_error(self):
+        model = PictModel("""
+A: 1, 2
+B: 3, 4
+
+{ A, B } @ x
+""")
+        # "@ x" is not a valid order, so the line is not a sub-model.
+        assert len(model.errors) > 0
 
 
 # ---------------------------------------------------------------------------

--- a/typescript/src/__tests__/pict-comments.test.ts
+++ b/typescript/src/__tests__/pict-comments.test.ts
@@ -1,0 +1,89 @@
+import { parse, classifyComments } from "../pict";
+import { PictModel } from "../pict";
+
+describe("PICT comment classification", () => {
+  it("attaches a single comment directly above a parameter", () => {
+    const { comments } = parse(`# RAID level
+Type: Single, Span, Stripe`);
+    expect(comments).toHaveLength(1);
+    expect(comments[0].attachedTo).toBe("Type");
+    expect(comments[0].text).toBe("RAID level");
+  });
+
+  it("joins a contiguous multi-line block and attaches it to the next parameter", () => {
+    const { comments } = parse(`# RAID level
+# Single=standalone, RAID-5=parity-striped
+Type: Single, Span, RAID-5`);
+    expect(comments).toHaveLength(1);
+    expect(comments[0].attachedTo).toBe("Type");
+    expect(comments[0].text).toBe(
+      "RAID level\nSingle=standalone, RAID-5=parity-striped",
+    );
+    expect(comments[0].lines).toHaveLength(2);
+  });
+
+  it("treats a comment separated by a blank line as freestanding", () => {
+    const { comments } = parse(`# just documentation
+
+Type: Single, Span`);
+    expect(comments).toHaveLength(1);
+    expect(comments[0].attachedTo).toBeNull();
+    expect(comments[0].text).toBe("just documentation");
+  });
+
+  it("a blank line splits one block into freestanding + attached", () => {
+    const { comments } = parse(`# header note
+
+# total size in GB
+Size: 10, 100, 1000`);
+    expect(comments).toHaveLength(2);
+    expect(comments[0].attachedTo).toBeNull();
+    expect(comments[0].text).toBe("header note");
+    expect(comments[1].attachedTo).toBe("Size");
+    expect(comments[1].text).toBe("total size in GB");
+  });
+
+  it("attaches the comment above an =ai output line to that output field", () => {
+    const { comments } = parse(`Type: Single, Span
+
+# Decide whether each configuration is valid. Answer valid or invalid.
+expected: =ai.choice`);
+    const attached = comments.filter((c) => c.attachedTo === "expected");
+    expect(attached).toHaveLength(1);
+    expect(attached[0].text).toMatch(/Decide whether each configuration is valid/);
+  });
+
+  it("strips '# ' and a single following space only", () => {
+    const { comments } = parse(`#no space
+Type: A, B`);
+    expect(comments[0].text).toBe("no space");
+  });
+
+  it("treats a comment above a non-parameter (constraint) line as freestanding", () => {
+    const { comments } = parse(`A: 1, 2
+B: 3, 4
+
+# this explains the constraint
+IF [A] = 1 THEN [B] = 3;`);
+    const constraintComment = comments.find((c) =>
+      c.text.includes("explains the constraint"),
+    );
+    expect(constraintComment).toBeDefined();
+    expect(constraintComment!.attachedTo).toBeNull();
+  });
+
+  it("records 1-based line numbers for each comment line", () => {
+    const { comments } = parse(`
+# line two
+Type: A`);
+    expect(comments[0].lines[0].line).toBe(2);
+  });
+
+  it("is exposed on PictModel and standalone classifyComments identically", () => {
+    const input = `# RAID level
+Type: Single, Span`;
+    const model = new PictModel(input);
+    expect(model.comments).toEqual(classifyComments(input));
+    expect(model.comments[0].attachedTo).toBe("Type");
+  });
+});

--- a/typescript/src/__tests__/pict.test.ts
+++ b/typescript/src/__tests__/pict.test.ts
@@ -622,14 +622,28 @@ C: c1, c2, c3
     }
   });
 
-  it('invalid sub-model line produces error', () => {
+  it('sub-model without an order uses the global order (per PICT spec)', () => {
     const model = new PictModel(`
 A: 1, 2
 B: 3, 4
 
 { A, B }
     `);
-    // "{ A, B }" without @ is not a valid sub-model, treated as constraint
+    // "{ A, B }" without @ is a valid sub-model; the order defaults to /o.
+    expect(errorMessages(model)).toHaveLength(0);
+    expect(model.subModels).toHaveLength(1);
+    expect(model.subModels[0]).toEqual({ fields: ['A', 'B'] });
+    expect(model.make().length).toBeGreaterThan(0);
+  });
+
+  it('malformed sub-model line (non-numeric order) produces error', () => {
+    const model = new PictModel(`
+A: 1, 2
+B: 3, 4
+
+{ A, B } @ x
+    `);
+    // "@ x" is not a valid order, so the line is not a sub-model.
     expect(errorMessages(model).length).toBeGreaterThan(0);
   });
 });

--- a/typescript/src/__tests__/pict.test.ts
+++ b/typescript/src/__tests__/pict.test.ts
@@ -824,6 +824,64 @@ IF [COLOR] IN {"Red", "Blue", "Green"} THEN [CATEGORY] = "Primary" ELSE [CATEGOR
     expect(model.filter(row3)).toBe(false);
   });
 
+  it('should handle IN conditions with numeric sets', () => {
+    // PICT's own docs use numeric IN sets, e.g. IN {512, 1024, 2048}.
+    const model = new PictModel(`
+CLUSTER: 512, 1024, 2048
+COMPRESSION: On, Off
+
+IF [CLUSTER] IN {512, 1024} THEN [COMPRESSION] = "Off";
+    `);
+    expect(errorMessages(model)).toEqual([]);
+    expect(model.filter({ CLUSTER: 512, COMPRESSION: 'Off' })).toBe(true);
+    expect(model.filter({ CLUSTER: 1024, COMPRESSION: 'Off' })).toBe(true);
+    expect(model.filter({ CLUSTER: 512, COMPRESSION: 'On' })).toBe(false);
+    // Value outside the set → antecedent false → row passes.
+    expect(model.filter({ CLUSTER: 2048, COMPRESSION: 'On' })).toBe(true);
+  });
+
+  it('should mix numeric and float values in an IN set', () => {
+    const model = new PictModel(`
+V: 1, 2.5, 3
+R: ok, ng
+
+IF [V] IN {2.5, 3} THEN [R] = "ok";
+    `);
+    expect(errorMessages(model)).toEqual([]);
+    expect(model.filter({ V: 2.5, R: 'ok' })).toBe(true);
+    expect(model.filter({ V: 3, R: 'ng' })).toBe(false);
+    expect(model.filter({ V: 1, R: 'ng' })).toBe(true);
+  });
+
+  it('should treat non-wildcard characters in LIKE as literals', () => {
+    // Only * and ? are wildcards; "." must match a literal dot, not any char.
+    const model = new PictModel(`
+VER: "4.8", "4.8.1", "4x8"
+OK: yes, no
+
+IF [VER] LIKE "4.8*" THEN [OK] = "yes";
+    `);
+    expect(errorMessages(model)).toEqual([]);
+    expect(model.filter({ VER: '4.8', OK: 'yes' })).toBe(true);
+    expect(model.filter({ VER: '4.8.1', OK: 'yes' })).toBe(true);
+    // "4x8" must NOT match "4.8*" because the dot is literal.
+    expect(model.filter({ VER: '4x8', OK: 'no' })).toBe(true);
+    expect(model.filter({ VER: '4.8', OK: 'no' })).toBe(false);
+  });
+
+  it('should handle ? and * wildcards in LIKE', () => {
+    const model = new PictModel(`
+NAME: Alice, Alicia, Bob
+TAG: a, b
+
+IF [NAME] LIKE "Alic?" THEN [TAG] = "a";
+    `);
+    expect(errorMessages(model)).toEqual([]);
+    expect(model.filter({ NAME: 'Alice', TAG: 'a' })).toBe(true);   // ? = one char
+    expect(model.filter({ NAME: 'Alicia', TAG: 'b' })).toBe(true);  // "Alicia" != "Alic?" → antecedent false
+    expect(model.filter({ NAME: 'Alice', TAG: 'b' })).toBe(false);
+  });
+
   it('should handle complex conditions with nested parentheses', () => {
     const model = new PictModel(`
 AGE: 18, 25

--- a/typescript/src/controller.ts
+++ b/typescript/src/controller.ts
@@ -211,8 +211,9 @@ export class Controller<T extends FactorsType> {
     }
 
     for (const sub of subModels) {
-      for (const keys of combinations(sub.fields, sub.strength)) {
-        const comb = range(0, sub.strength).map((i) => this.serials.get(keys[i]) as PairType);
+      const subStrength = sub.strength ?? this.strength;
+      for (const keys of combinations(sub.fields, subStrength)) {
+        const comb = range(0, subStrength).map((i) => this.serials.get(keys[i]) as PairType);
         for (let pair of product(...comb)) {
           pairs.push(pair.sort(ascOrder));
         }
@@ -605,7 +606,7 @@ export class Controller<T extends FactorsType> {
   get allStrengths(): number[] {
     const strengths = new Set([this.strength]);
     for (const sub of this.options.subModels ?? []) {
-      strengths.add(sub.strength);
+      strengths.add(sub.strength ?? this.strength);
     }
     return [...strengths];
   }

--- a/typescript/src/pict/constraints.ts
+++ b/typescript/src/pict/constraints.ts
@@ -361,7 +361,12 @@ export class PictConstraintsLexer {
         if (typeof patternStr !== 'string') {
           throw new Error('Expected string pattern after LIKE');
         }
-        const regexPattern = patternStr.replace(/\*/g, '.*').replace(/\?/g, '.');
+        // Escape every regex metacharacter (including * and ?), then re-enable
+        // only the two PICT wildcards: * → any run, ? → any single char.
+        const regexPattern = patternStr
+          .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+          .replace(/\\\*/g, '.*')
+          .replace(/\\\?/g, '.');
         const regex = new RegExp('^' + regexPattern + '$', ci ? 'i' : '');
         return (row) => regex.test(left(row));
       }
@@ -387,8 +392,8 @@ export class PictConstraintsLexer {
       }
     }
 
-    const parseSet: () => Set<string> = () => {
-      const elements: string[] = [];
+    const parseSet: () => Set<string | number> = () => {
+      const elements: (string | number)[] = [];
       let token = nextToken();
       if (token && token.type === TokenType.LBRACE) {
         token = nextToken();
@@ -398,6 +403,8 @@ export class PictConstraintsLexer {
             const lookup = ci ? raw.toLowerCase() : raw;
             const resolved = this.aliases.get(lookup) ?? raw;
             elements.push(norm(resolved));
+          } else if (token.type === TokenType.NUMBER) {
+            elements.push(parseFloat(token.value));
           } else if (token.type !== TokenType.COMMA && token.type !== TokenType.WHITESPACE) {
             throw new Error(`Unexpected token in array: ${token.value}`);
           }

--- a/typescript/src/pict/index.ts
+++ b/typescript/src/pict/index.ts
@@ -1,6 +1,6 @@
 export { PictModel } from './model';
 export type { PictModelOptions } from './model';
-export { parse } from './parse';
+export { parse, classifyComments } from './parse';
 export type { ParseOptions, ParseResult } from './parse';
 export { weightsByValue } from './weights';
 export { PictModelError } from './types';
@@ -9,4 +9,5 @@ export type {
   PictModelIssue,
   IssueSeverity,
   IssueSource,
+  CommentBlock,
 } from './types';

--- a/typescript/src/pict/model.ts
+++ b/typescript/src/pict/model.ts
@@ -5,7 +5,7 @@ import type {
   SubModelType,
 } from '../types';
 import { Controller } from '../controller';
-import type { PictFactorsType, PictModelIssue } from './types';
+import type { CommentBlock, PictFactorsType, PictModelIssue } from './types';
 import { PictModelError } from './types';
 import { parse } from './parse';
 import type { PictConstraintsLexer } from './constraints';
@@ -21,6 +21,7 @@ export class PictModel {
   private _negatives: Map<string, Set<string | number>>;
   private _weights: { [factorKey: string]: { [index: number]: number } };
   private _lexer: PictConstraintsLexer | null;
+  private _comments: CommentBlock[];
   private _controller: Controller<PictFactorsType> | null = null;
   public issues: PictModelIssue[];
 
@@ -33,6 +34,7 @@ export class PictModel {
     this._negatives = result.negatives;
     this._weights = result.weights;
     this._lexer = result.lexer;
+    this._comments = result.comments;
     this.issues = result.issues;
 
     if (strict && this.issues.some(i => i.severity === "error")) {
@@ -45,6 +47,7 @@ export class PictModel {
   get constraints(): Expression[] { return this._modelConstraints(); }
   get negatives(): Map<string, Set<string | number>> { return this._negatives; }
   get weights(): { [factorKey: string]: { [index: number]: number } } { return this._weights; }
+  get comments(): CommentBlock[] { return this._comments; }
   get progress(): number { return this._controller?.progress ?? 0; }
   get stats() { return this._controller?.stats ?? null; }
 

--- a/typescript/src/pict/parse.ts
+++ b/typescript/src/pict/parse.ts
@@ -1,5 +1,5 @@
 import type { SubModelType } from '../types';
-import type { PictFactorsType, PictModelIssue, SourceLine } from './types';
+import type { CommentBlock, PictFactorsType, PictModelIssue, SourceLine } from './types';
 import { isParameterLine, parseParameters } from './parameters';
 import { parseSubModel, subModelPattern } from './subModels';
 import { PictConstraintsLexer } from './constraints';
@@ -17,6 +17,8 @@ export interface ParseResult {
   subModels: SubModelType[];
   lexer: PictConstraintsLexer | null;
   issues: PictModelIssue[];
+  /** Comment blocks, each classified as a field description or freestanding. */
+  comments: CommentBlock[];
 }
 
 interface SplitSections {
@@ -58,6 +60,60 @@ function splitSections(input: string): SplitSections {
       .join('\n'),
     constraintStartLine: constraintStart + 1,
   };
+}
+
+/** Strip a leading `#` and one optional space from a comment line. */
+function stripComment(text: string): string {
+  return text.trim().replace(/^#\s?/, '');
+}
+
+/**
+ * Classify every comment (`#`) block in the model.
+ *
+ * A block is a maximal run of consecutive comment lines. It is **field-attached**
+ * (its `attachedTo` is the following parameter's key) when the very next line is
+ * a parameter line with no blank line between; otherwise it is **freestanding**
+ * (`attachedTo` = null). A blank line always ends a block and detaches it.
+ *
+ * This is the single source of truth for both prompt assembly (field-attached
+ * comments become per-field descriptions / the task on the output line) and the
+ * editor's syntax highlighting.
+ */
+export function classifyComments(input: string): CommentBlock[] {
+  const lines = input.split('\n');
+  const blocks: CommentBlock[] = [];
+  let pending: SourceLine[] = [];
+
+  const flush = (attachedTo: string | null) => {
+    if (pending.length === 0) {
+      return;
+    }
+    blocks.push({
+      lines: pending,
+      text: pending.map(l => stripComment(l.text)).join('\n'),
+      attachedTo,
+    });
+    pending = [];
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const text = lines[i];
+    const trimmed = text.trim();
+    if (trimmed.startsWith('#')) {
+      pending.push({ text, line: i + 1 });
+    } else if (trimmed === '') {
+      // A blank line detaches any pending block.
+      flush(null);
+    } else if (isParameterLine(trimmed)) {
+      // Adjacent (no blank line) → describes this parameter.
+      flush(trimmed.slice(0, trimmed.indexOf(':')).trim());
+    } else {
+      // Sub-model / constraint / other → not a field description.
+      flush(null);
+    }
+  }
+  flush(null);
+  return blocks;
 }
 
 /**
@@ -120,5 +176,14 @@ export function parse(input: string, options: ParseOptions = {}): ParseResult {
     });
   }
 
-  return { factors, aliases, negatives, weights, subModels, lexer, issues };
+  return {
+    factors,
+    aliases,
+    negatives,
+    weights,
+    subModels,
+    lexer,
+    issues,
+    comments: classifyComments(input),
+  };
 }

--- a/typescript/src/pict/subModels.ts
+++ b/typescript/src/pict/subModels.ts
@@ -1,12 +1,15 @@
 import type { SubModelType } from '../types';
 
-// Parse sub-model line: { P1, P2, P3 } @ N
-export const subModelPattern = /^\{\s*(.+?)\s*\}\s*@\s*(\d+)\s*$/;
+// Parse sub-model line: { P1, P2, P3 } @ N  — the `@ N` order is optional and,
+// when absent, the global order (`/o`) is applied at generation time.
+export const subModelPattern = /^\{\s*(.+?)\s*\}\s*(?:@\s*(\d+))?\s*$/;
 
 export function parseSubModel(line: string): SubModelType | null {
   const match = line.match(subModelPattern);
   if (!match) return null;
   const fields = match[1].split(',').map(k => k.trim()).filter(k => k !== '');
-  const strength = parseInt(match[2], 10);
-  return { fields, strength };
+  if (match[2] === undefined) {
+    return { fields };
+  }
+  return { fields, strength: parseInt(match[2], 10) };
 }

--- a/typescript/src/pict/types.ts
+++ b/typescript/src/pict/types.ts
@@ -6,6 +6,23 @@ export interface SourceLine {
   line: number; // 1-based
 }
 
+/**
+ * A contiguous block of comment (`#`) lines, classified by what it describes.
+ *
+ * A block directly above a parameter line, with no blank line between, is a
+ * field description (`attachedTo` = that parameter's key). A block separated by
+ * a blank line, or sitting above a non-parameter line, is freestanding
+ * (`attachedTo` = null) and is treated as documentation only.
+ */
+export interface CommentBlock {
+  /** The comment lines in this block, in source order. */
+  lines: SourceLine[];
+  /** Comment text with the leading `#` (and one space) stripped, joined by `\n`. */
+  text: string;
+  /** The parameter key this block describes, or null if freestanding. */
+  attachedTo: string | null;
+}
+
 export type IssueSeverity = "error" | "warning";
 export type IssueSource = "factor" | "subModel" | "constraint";
 

--- a/typescript/src/types.ts
+++ b/typescript/src/types.ts
@@ -49,7 +49,8 @@ export interface CriterionArgsType {
 
 export interface SubModelType {
   fields: ScalarType[];
-  strength: number;
+  /** Combinatory order. When omitted, the global order (`/o`, default 2) is used. */
+  strength?: number;
 };
 
 export type WeightsType = { [factorKey: string]: { [index: number]: number } };


### PR DESCRIPTION
## Summary

Changes to the PICT model parser (TypeScript + Python):

1. **Spec-conformance fixes** — align constraint & sub-model parsing with Microsoft PICT's documented syntax (`pict/doc/pict.md`).
2. **Comment classification** — parse `#` comments into structured, per-field descriptions (TS only).
3. **Docs** — reflect the above in the PictModel reference and the Compatible PICT tool page.

## 1. Spec-conformance fixes

| # | Issue | TS | Python |
|---|-------|----|--------|
| 1 | Numeric `IN` sets rejected — `IN {512, 1024}` threw `Unexpected token in array` (this is the value form used in PICT's own docs) | ✅ fixed | ✅ fixed |
| 2 | `LIKE` treated regex metacharacters as special — `LIKE "4.8*"` matched `4x8.1` because `.` leaked into the regex | ✅ fixed | already correct (`re.escape`) |
| 3 | Sub-model order was mandatory — `{ A, B }` without `@ N` was rejected; per spec the order is optional and defaults to the global order (`/o`) | ✅ fixed | ✅ fixed |

- **Numeric IN sets** — the set parser now accepts `NUMBER` tokens (integers/floats), not just quoted strings.
- **LIKE escaping** (TS) — escape every regex metacharacter, then restore only `*` → `.*` and `?` → `.` as wildcards, matching PICT semantics where all other characters are literal.
- **Optional sub-model order** — `SubModelType.strength` is optional and resolved to the global order at generation time (`sub.strength ?? this.strength`). A malformed order such as `{ A, B } @ x` still produces an error.

## 2. Comment classification

Each maximal run of `#` lines becomes a `CommentBlock`, classified as either a **field description** (attached to the parameter directly below it, no blank line between) or **freestanding documentation** (separated by a blank line, or above a constraint / non-parameter line). `classifyComments()` is the single source of truth; `CommentBlock` and `classifyComments` are exported, and `PictModel.comments` exposes the blocks.

## 3. Docs

- `docs/contents/reference/pict.mdx` — documented numeric IN sets, optional sub-model order (syntax table + PICT-differences section), and LIKE literal semantics.
- `docs/contents/tools/pict-online.mdx` — same clarifications in the tool page's Constraints/Parameters tables.

## Testing

- TypeScript: `npm test` → **18 suites, 179 tests passing** (includes `pict-comments.test.ts` and new numeric/float-IN and LIKE tests).
- Python: `pytest` → **47 tests passing** (numeric & float IN sets, order-less sub-models, malformed order, LIKE literal/wildcard).

## Not included

- The alias-in-constraint-literal behavior (`[SKU] = "Datacenter"` matching an alias rather than only the first name) is a separate spec question left for a design decision.
- Unrelated working-tree changes (Buy Me A Coffee widget, favicons, vendored `pict/` reference repo) are intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
